### PR TITLE
Added support for reject_on_worker_lost

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -8,6 +8,17 @@ This document contains change notes for bugfix releases in the 3.1.x series
 (Cipater), please see :ref:`whatsnew-3.1` for an overview of what's
 new in Celery 3.1.
 
+.. _version-3.1.26-1-jer-2:
+
+3.1.26-1-jer2
+======
+:release-date: 2022-03-28 15:00 PM IST
+:release-by: Linar Savion
+
+- Backported reject_on_worker_lost option, extended it to be handled just like regular exceptions (max_retries, etc..)
+.. _version-3.1.26:
+
+
 .. _version-3.1.26-1-jer-1:
 
 3.1.26-1-jer1

--- a/celery/__init__.py
+++ b/celery/__init__.py
@@ -19,7 +19,7 @@ version_info_t = namedtuple(
 )
 
 SERIES = 'Cipater'
-VERSION = version_info_t(3, 1, 26, '_1', '_jer1')
+VERSION = version_info_t(3, 1, 26, '_1', '_jer2')
 __version__ = '{0.major}.{0.minor}.{0.micro}{0.releaselevel}'.format(VERSION)
 __author__ = 'Ask Solem'
 __contact__ = 'ask@celeryproject.org'

--- a/celery/app/task.py
+++ b/celery/app/task.py
@@ -597,7 +597,7 @@ class Task(object):
         return self.subtask(args, kwargs, options, type=self, **extra_options)
 
     def retry(self, args=None, kwargs=None, exc=None, throw=True,
-              eta=None, countdown=None, max_retries=None, **options):
+              eta=None, countdown=None, max_retries=None, _request=None, **options):
         """Retry the task.
 
         :param args: Positional arguments to retry with.
@@ -659,7 +659,8 @@ class Task(object):
         to convey that the rest of the block will not be executed.
 
         """
-        request = self.request
+        # If retry was called with a custom request
+        request = _request or self.request
         retries = request.retries + 1
         max_retries = self.max_retries if max_retries is None else max_retries
 

--- a/celery/app/trace.py
+++ b/celery/app/trace.py
@@ -84,11 +84,11 @@ class TraceInfo(object):
             FAILURE: self.handle_failure,
         }[self.state](task, store_errors=store_errors)
 
-    def handle_retry(self, task, store_errors=True):
+    def handle_retry(self, task, _request=None, store_errors=True):
         """Handle retry exception."""
         # the exception raised is the Retry semi-predicate,
         # and it's exc' attribute is the original exception raised (if any).
-        req = task.request
+        req = _request or task.request
         type_, _, tb = sys.exc_info()
         try:
             reason = self.retval


### PR DESCRIPTION
Extended original implementation, `WorkerLostError` exceptions are now handled just like any other exception, and respect the max_retries and retry_delay options.