### PR TITLE
GCSBackend: use configured threadpool_maxsize in mget

### DIFF
--- a/celery/backends/gcs.py
+++ b/celery/backends/gcs.py
@@ -119,7 +119,7 @@ class GCSBackend(KeyValueStoreBackend):
             blob.delete(retry=self._retry_policy)
 
     def mget(self, keys):
-        with ThreadPoolExecutor() as pool:
+        with ThreadPoolExecutor(self._threadpool_maxsize) as pool:
             return list(pool.map(self.get, keys))
 
     @property


### PR DESCRIPTION
Without this, ThreadPoolExecutor() defaults to unbounded workers, ignoring the _threadpool_maxsize setting already used elsewhere.

*Note*: Before submitting this pull request, please review our [contributing
guidelines](https://docs.celeryq.dev/en/main/contributing.html).

## Description

<!-- Please describe your pull request.

NOTE: All patches should be made against main, not a maintenance branch like
3.1, 2.5, etc.  That is unless the bug is already fixed in main, but not in
that version series.

If it fixes a bug or resolves a feature request,
be sure to link to that issue via (Fixes #4412) for example.
-->
